### PR TITLE
netlify_site_domain_settings_changes fix update in place without changes

### DIFF
--- a/internal/provider/site_domain_settings_resource.go
+++ b/internal/provider/site_domain_settings_resource.go
@@ -133,13 +133,26 @@ func (r *siteDomainSettingsResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	state.CustomDomain = types.StringValue(site.CustomDomain)
+	if site.CustomDomain != "" {
+		state.CustomDomain = types.StringValue(site.CustomDomain)
+	} else {
+		state.CustomDomain = types.StringNull()
+	}
 	state.DomainAliases = make([]types.String, len(site.DomainAliases))
 	for i, domainAlias := range site.DomainAliases {
 		state.DomainAliases[i] = types.StringValue(domainAlias)
 	}
-	state.BranchDeployCustomDomain = types.StringValue(site.BranchDeployCustomDomain)
-	state.DeployPreviewCustomDomain = types.StringValue(site.DeployPreviewCustomDomain)
+	if site.BranchDeployCustomDomain != "" {
+		state.BranchDeployCustomDomain = types.StringValue(site.BranchDeployCustomDomain)
+	} else {
+		state.BranchDeployCustomDomain = types.StringNull()
+	}
+
+	if site.DeployPreviewCustomDomain != "" {
+		state.DeployPreviewCustomDomain = types.StringValue(site.DeployPreviewCustomDomain)
+	} else {
+		state.DeployPreviewCustomDomain = types.StringNull()
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 	if resp.Diagnostics.HasError() {

--- a/internal/provider/site_domain_settings_resource_test.go
+++ b/internal/provider/site_domain_settings_resource_test.go
@@ -54,3 +54,44 @@ func TestAccSiteDomainSettings(t *testing.T) {
 		},
 	}, func(s *terraform.State) error { return nil })
 }
+
+func TestAccSiteDomainSettingsNullFields(t *testing.T) {
+	// Test case for preventing drift when optional fields are null from API
+	accTest(t, []resource.TestStep{
+		{
+			Config: `resource "netlify_site_domain_settings" "null_fields" {
+  site_id       = "5b407d6d-9385-4e7a-a4c4-8efc11ea3c26"
+  custom_domain = "tf-test-null-fields.examplepetstore.com"
+}`,
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("netlify_site_domain_settings.null_fields", "site_id", "5b407d6d-9385-4e7a-a4c4-8efc11ea3c26"),
+				resource.TestCheckResourceAttr("netlify_site_domain_settings.null_fields", "custom_domain", "tf-test-null-fields.examplepetstore.com"),
+				resource.TestCheckResourceAttr("netlify_site_domain_settings.null_fields", "domain_aliases.#", "0"),
+				// These should be null/empty when not set
+				resource.TestCheckNoResourceAttr("netlify_site_domain_settings.null_fields", "branch_deploy_custom_domain"),
+				resource.TestCheckNoResourceAttr("netlify_site_domain_settings.null_fields", "deploy_preview_custom_domain"),
+			),
+		},
+		{
+			// Second step with same config should not detect changes (no drift)
+			Config: `resource "netlify_site_domain_settings" "null_fields" {
+  site_id       = "5b407d6d-9385-4e7a-a4c4-8efc11ea3c26"
+  custom_domain = "tf-test-null-fields.examplepetstore.com"
+}`,
+			PlanOnly: true,
+			Check: resource.ComposeAggregateTestCheckFunc(
+				resource.TestCheckResourceAttr("netlify_site_domain_settings.null_fields", "site_id", "5b407d6d-9385-4e7a-a4c4-8efc11ea3c26"),
+				resource.TestCheckResourceAttr("netlify_site_domain_settings.null_fields", "custom_domain", "tf-test-null-fields.examplepetstore.com"),
+				resource.TestCheckResourceAttr("netlify_site_domain_settings.null_fields", "domain_aliases.#", "0"),
+			),
+		},
+		{
+			ResourceName:                         "netlify_site_domain_settings.null_fields",
+			ImportState:                          true,
+			ImportStateId:                        "5b407d6d-9385-4e7a-a4c4-8efc11ea3c26",
+			ImportStateVerifyIdentifierAttribute: "site_id",
+			ImportStateVerify:                    true,
+			ImportStateVerifyIgnore:              []string{"last_updated"},
+		},
+	}, func(s *terraform.State) error { return nil })
+}


### PR DESCRIPTION
This error fixes state when I specify `netlify_site_domain_settings_changes` resource like this:

```terraform
resource "netlify_site_domain_settings" "my_site" {
  site_id                      = data.netlify_site.my_site.id
  custom_domain       = "www.my.site"
}
```

This cause changes on each plan/apply:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # netlify_site_domain_settings.my_site will be updated in-place
  ~ resource "netlify_site_domain_settings" "my_site" {
      ~ last_updated                 = "Wednesday, 25-Jun-25 22:58:25 PDT" -> (known after apply)
        # (5 unchanged attributes hidden)
    }
```

This changes fixes the issue.

This pull request improves the handling of optional fields in the `site_domain_settings` resource by ensuring null values are explicitly managed and adds a new test case to prevent configuration drift. The changes enhance both the functionality and reliability of the resource.

### Enhancements to `site_domain_settings` resource:

* Updated the `Read` method in `internal/provider/site_domain_settings_resource.go` to explicitly set optional fields (`CustomDomain`, `BranchDeployCustomDomain`, and `DeployPreviewCustomDomain`) to `StringNull` when they are not provided by the API. This ensures consistent state representation for optional fields.

### New test case for preventing configuration drift:

* Added a new test function `TestAccSiteDomainSettingsNullFields` in `internal/provider/site_domain_settings_resource_test.go`. This test verifies that optional fields remain null when not set and ensures no drift occurs when reapplying the same configuration. It also includes an import verification step.